### PR TITLE
Create post routes

### DIFF
--- a/api/src/controllers/postController.ts
+++ b/api/src/controllers/postController.ts
@@ -58,7 +58,15 @@ export const updatePostById = (postService: PostService = getDefaultPostService(
       const postId = req.params.id
       const newData = req.body
 
-      const response: Post | null = await postService.updatePostById(parseInt(postId), newData)
+      const response: Post | ValidationError | null = await postService.updatePostById(
+        parseInt(postId),
+        newData
+      )
+
+      if (response instanceof ValidationError) {
+        res.status(400).json({ message: response.message })
+        return
+      }
 
       if (response == null) {
         res.status(404).json({ data: null })

--- a/api/src/controllers/postController.ts
+++ b/api/src/controllers/postController.ts
@@ -1,0 +1,59 @@
+import { Request, Response } from 'express'
+
+import PostService, { getDefaultPostService } from '../services/postService'
+import { Post } from '@prisma/client'
+import { ERROR_CODES } from '../prisma'
+
+export const getPostById = (postService: PostService = getDefaultPostService()) => {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const postId = req.params.id
+
+      const post: Post | null = await postService.getPostById(parseInt(postId))
+
+      if (post == null) {
+        res.status(404).json({ data: null })
+      } else {
+        res.status(200).json({ data: post })
+      }
+    } catch {
+      res.status(500).send()
+    }
+  }
+}
+
+export const updatePostById = (postService: PostService = getDefaultPostService()) => {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const postId = req.params.id
+      const newData = req.body
+
+      const response: Post | null = await postService.updatePostById(parseInt(postId), newData)
+
+      if (response == null) {
+        res.status(404).json({ data: null })
+      } else {
+        res.status(200).json({ data: response })
+      }
+    } catch {
+      res.status(500).send()
+    }
+  }
+}
+
+export const deletePostById = (postService: PostService = getDefaultPostService()) => {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const postId = req.params.id
+      const post: Post = await postService.deletePostById(parseInt(postId))
+
+      res.status(200).json({ data: { post } })
+    } catch (e) {
+      if (e.code == ERROR_CODES.NoRecordFound) {
+        res.status(404).send()
+      } else {
+        res.status(500).send()
+      }
+    }
+  }
+}

--- a/api/src/controllers/postController.ts
+++ b/api/src/controllers/postController.ts
@@ -3,6 +3,36 @@ import { Request, Response } from 'express'
 import PostService, { getDefaultPostService } from '../services/postService'
 import { Post } from '@prisma/client'
 import { ERROR_CODES } from '../prisma'
+import CreatePostInput from '../types/CreatePostInput'
+import { ValidationError } from '../util/validations/ValidationError'
+
+export const createPostByUserId = (postService: PostService = getDefaultPostService()) => {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const data = req.body
+      const userId = req.params.id
+
+      const postPayload: CreatePostInput = {
+        title: data.title,
+        description: data.description,
+      }
+
+      const response: Post | ValidationError = await postService.createPostByUserId(
+        parseInt(userId),
+        postPayload
+      )
+
+      if (response instanceof ValidationError) {
+        res.status(400).json({ message: response.message })
+        return
+      }
+
+      res.status(201).json({ data: response })
+    } catch {
+      res.status(500).send()
+    }
+  }
+}
 
 export const getPostById = (postService: PostService = getDefaultPostService()) => {
   return async (req: Request, res: Response): Promise<void> => {

--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -10,6 +10,15 @@ class PostRepository {
     this.postClient = postClient
   }
 
+  async createPostByUserId(userId: number, post: CreatePostInput): Promise<Post> {
+    return await this.postClient.create({
+      data: {
+        userId,
+        ...post,
+      },
+    })
+  }
+
   async getPostById(id: number): Promise<Post> {
     return await this.postClient.findUnique({ where: { id } })
   }

--- a/api/src/repositories/postRepository.ts
+++ b/api/src/repositories/postRepository.ts
@@ -1,0 +1,30 @@
+import { Prisma, Post } from '@prisma/client'
+import CreatePostInput from '../types/CreatePostInput'
+import UpdatePostInput from '../types/UpdatePostInput'
+import { prisma } from '../prisma'
+
+class PostRepository {
+  postClient: Prisma.PostDelegate
+
+  constructor(postClient: Prisma.PostDelegate) {
+    this.postClient = postClient
+  }
+
+  async getPostById(id: number): Promise<Post> {
+    return await this.postClient.findUnique({ where: { id } })
+  }
+
+  async updatePostById(id: number, data: UpdatePostInput): Promise<Post> {
+    return await this.postClient.update({ where: { id }, data })
+  }
+
+  async deletePostById(id: number): Promise<Post> {
+    return await this.postClient.delete({ where: { id } })
+  }
+}
+
+export const getDefaultPostRepository = (): PostRepository => {
+  return new PostRepository(prisma.post)
+}
+
+export default PostRepository

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -1,11 +1,13 @@
 import BodyParser from 'body-parser'
 import Router from 'express-promise-router'
 import UserRoute from './routes/userRoute'
+import PostRoute from './routes/postRoute'
 
 const router = Router()
 
 router.use(BodyParser.json())
 
 router.use('/api/users', UserRoute)
+router.use('/api/posts', PostRoute)
 
 export default router

--- a/api/src/routes/postRoute.ts
+++ b/api/src/routes/postRoute.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express'
+
+import { getPostById, updatePostById, deletePostById } from '../controllers/postController'
+
+const router = Router()
+
+router.get('/:id', getPostById())
+router.put('/:id', updatePostById())
+router.delete('/:id', deletePostById())
+
+export default router

--- a/api/src/routes/postRoute.ts
+++ b/api/src/routes/postRoute.ts
@@ -1,9 +1,15 @@
 import { Router } from 'express'
 
-import { getPostById, updatePostById, deletePostById } from '../controllers/postController'
+import {
+  getPostById,
+  updatePostById,
+  deletePostById,
+  createPostByUserId,
+} from '../controllers/postController'
 
 const router = Router()
 
+router.post('/user/:id', createPostByUserId())
 router.get('/:id', getPostById())
 router.put('/:id', updatePostById())
 router.delete('/:id', deletePostById())

--- a/api/src/services/postService.ts
+++ b/api/src/services/postService.ts
@@ -30,7 +30,7 @@ class PostService {
   }
 
   async getPostById(id: number): Promise<Post | null> {
-    let post: Post | null = await this.postRepository.getPostById(id)
+    const post: Post | null = await this.postRepository.getPostById(id)
 
     if (post != null) {
       return {
@@ -46,8 +46,15 @@ class PostService {
     return null
   }
 
-  async updatePostById(id: number, postData: UpdatePostInput): Promise<Post | null> {
-    let post = await this.postRepository.updatePostById(id, postData)
+  async updatePostById(
+    id: number,
+    postData: UpdatePostInput
+  ): Promise<Post | ValidationError | null> {
+    const error = validateUpdatePostInput(postData)
+
+    if (error != null) return error
+
+    const post = await this.postRepository.updatePostById(id, postData)
 
     return {
       id: post.id,
@@ -84,6 +91,24 @@ export const validateCreatePostInput = (postData: CreatePostInput): ValidationEr
   }
 
   if (postData.description.length > MAX_DESCRIPTION_INPUT) {
+    return new ValidationError(
+      ValidationCode.INVALID_FIELD,
+      'Description length limited to 500 characters'
+    )
+  }
+
+  return null
+}
+
+export const validateUpdatePostInput = (postData: UpdatePostInput): ValidationError | null => {
+  if (postData.title && postData.title.length > MAX_TITLE_INPUT) {
+    return new ValidationError(
+      ValidationCode.INVALID_FIELD,
+      'Title length limited to 255 characters'
+    )
+  }
+
+  if (postData.description && postData.description.length > MAX_DESCRIPTION_INPUT) {
     return new ValidationError(
       ValidationCode.INVALID_FIELD,
       'Description length limited to 500 characters'

--- a/api/src/services/postService.ts
+++ b/api/src/services/postService.ts
@@ -1,0 +1,54 @@
+import { Post } from '@prisma/client'
+
+import PostRepository, { getDefaultPostRepository } from '../repositories/postRepository'
+import UpdatePostInput from '../types/UpdatePostInput'
+
+class PostService {
+  postRepository: PostRepository
+
+  constructor(postRepository: PostRepository) {
+    this.postRepository = postRepository
+  }
+
+  async getPostById(id: number): Promise<Post | null> {
+    let post: Post | null = await this.postRepository.getPostById(id)
+
+    if (post != null) {
+      return {
+        id: post.id,
+        title: post.title,
+        description: post.description,
+        userId: post.userId,
+        updatedAt: post.updatedAt,
+        createdAt: post.createdAt,
+      }
+    }
+
+    return null
+  }
+
+  async updatePostById(id: number, postData: UpdatePostInput): Promise<Post | null> {
+    let post = await this.postRepository.updatePostById(id, postData)
+
+    return {
+      id: post.id,
+      title: post.title,
+      description: post.description,
+      userId: post.userId,
+      updatedAt: post.updatedAt,
+      createdAt: post.createdAt,
+    }
+  }
+
+  async deletePostById(id: number): Promise<Post> {
+    return await this.postRepository.deletePostById(id)
+  }
+}
+
+export const getDefaultPostService = () => {
+  let postRepo = getDefaultPostRepository()
+
+  return new PostService(postRepo)
+}
+
+export default PostService

--- a/api/src/services/postService.ts
+++ b/api/src/services/postService.ts
@@ -2,12 +2,31 @@ import { Post } from '@prisma/client'
 
 import PostRepository, { getDefaultPostRepository } from '../repositories/postRepository'
 import UpdatePostInput from '../types/UpdatePostInput'
+import CreatePostInput from '../types/CreatePostInput'
+import { ValidationError, ValidationCode } from '../util/validations/ValidationError'
 
 class PostService {
   postRepository: PostRepository
 
   constructor(postRepository: PostRepository) {
     this.postRepository = postRepository
+  }
+
+  async createPostByUserId(id: number, postData: CreatePostInput): Promise<Post | ValidationError> {
+    const error = validateCreatePostInput(postData)
+
+    if (error != null) return error
+
+    const post: Post = await this.postRepository.createPostByUserId(id, postData)
+
+    return {
+      id: post.id,
+      title: post.title,
+      description: post.description,
+      userId: post.userId,
+      updatedAt: post.updatedAt,
+      createdAt: post.createdAt,
+    }
   }
 
   async getPostById(id: number): Promise<Post | null> {
@@ -43,6 +62,35 @@ class PostService {
   async deletePostById(id: number): Promise<Post> {
     return await this.postRepository.deletePostById(id)
   }
+}
+
+export const MAX_TITLE_INPUT = 255
+export const MAX_DESCRIPTION_INPUT = 500
+
+export const validateCreatePostInput = (postData: CreatePostInput): ValidationError | null => {
+  if (postData.title == null || postData.title == undefined) {
+    return new ValidationError(ValidationCode.MISSING_FIELD, 'Title required')
+  }
+
+  if (postData.description == null || postData.description == undefined) {
+    return new ValidationError(ValidationCode.MISSING_FIELD, 'Description required')
+  }
+
+  if (postData.title.length > MAX_TITLE_INPUT) {
+    return new ValidationError(
+      ValidationCode.INVALID_FIELD,
+      'Title length limited to 255 characters'
+    )
+  }
+
+  if (postData.description.length > MAX_DESCRIPTION_INPUT) {
+    return new ValidationError(
+      ValidationCode.INVALID_FIELD,
+      'Description length limited to 500 characters'
+    )
+  }
+
+  return null
 }
 
 export const getDefaultPostService = () => {

--- a/api/src/services/userService.ts
+++ b/api/src/services/userService.ts
@@ -69,11 +69,11 @@ class UserService {
 }
 
 export const validateCreateUserInput = (userData: CreateUserInput): ValidationError | null => {
-  if (userData.username == null) {
+  if (userData.username == null || userData.username == undefined) {
     return new ValidationError(ValidationCode.MISSING_FIELD, 'Username required')
   }
 
-  if (userData.email == null) {
+  if (userData.email == null || userData.email == undefined) {
     return new ValidationError(ValidationCode.MISSING_FIELD, 'Email required')
   }
 

--- a/api/src/types/CreatePostInput.ts
+++ b/api/src/types/CreatePostInput.ts
@@ -1,0 +1,6 @@
+type CreatePostInput = {
+  title: string
+  description: string
+}
+
+export default CreatePostInput

--- a/api/src/types/UpdatePostInput.ts
+++ b/api/src/types/UpdatePostInput.ts
@@ -1,0 +1,6 @@
+type UpdatePostInput = {
+  title?: string
+  description?: string
+}
+
+export default UpdatePostInput

--- a/api/tests/controllers/postController.spec.ts
+++ b/api/tests/controllers/postController.spec.ts
@@ -1,0 +1,324 @@
+import { describe } from 'mocha'
+import chai, { expect } from 'chai'
+import sinon, { SinonSpy, fake, stub } from 'sinon'
+import chaiAsPromised from 'chai-as-promised'
+import { Request } from 'express'
+import { getPostById, updatePostById, deletePostById } from '../../src/controllers/postController'
+import PostService from '../../src/services/postService'
+import { getDefaultPostRepository } from '../../src/repositories/postRepository'
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
+import { Post } from '@prisma/client'
+
+chai.use(chaiAsPromised)
+
+describe('PostController', () => {
+  let postService: PostService
+
+  let getPostByIdWithStub: Function
+  let updatePostByIdWithStub: Function
+  let deletePostByIdWithStub: Function
+
+  let fakePostServiceGetPostById: SinonSpy
+  let fakePostServiceUpdatePostById: SinonSpy
+  let fakePostServiceDeletePostById: SinonSpy
+
+  before(() => {
+    postService = new PostService(getDefaultPostRepository())
+  })
+
+  describe('#getPostById', () => {
+    describe('post found', () => {
+      before(() => {
+        fakePostServiceGetPostById = sinon.replace(
+          postService,
+          'getPostById',
+          fake.resolves(defaultPost())
+        )
+
+        getPostByIdWithStub = getPostById(postService)
+      })
+
+      after(() => {
+        sinon.restore()
+      })
+
+      it('should get post by id', async () => {
+        const postId = 1
+
+        const mockRequest = {
+          params: { id: postId },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await getPostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(fakePostServiceGetPostById, postId)
+      })
+
+      it('should return a 200 code', async () => {
+        const postId = 1
+
+        const mockRequest = {
+          params: { id: postId },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await getPostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(mockResponse.status, 200)
+      })
+    })
+
+    describe('post not found', () => {
+      before(() => {
+        let postServiceResult = null
+
+        fakePostServiceGetPostById = sinon.replace(
+          postService,
+          'getPostById',
+          fake.resolves(postServiceResult)
+        )
+
+        getPostByIdWithStub = getPostById(postService)
+      })
+
+      after(() => {
+        sinon.restore()
+      })
+
+      it('should return null', async () => {
+        const postId = 1
+
+        const mockRequest = {
+          params: { id: postId },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await getPostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(mockResponse.json, { data: null })
+      })
+
+      it('should return a 404 code', async () => {
+        const postId = 1
+
+        const mockRequest = {
+          params: { id: postId },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await getPostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(mockResponse.status, 404)
+      })
+    })
+  })
+
+  describe('#updatePostById', () => {
+    describe('post found', () => {
+      before(() => {
+        fakePostServiceUpdatePostById = sinon.replace(
+          postService,
+          'updatePostById',
+          fake.resolves(defaultPost())
+        )
+
+        updatePostByIdWithStub = updatePostById(postService)
+      })
+
+      after(() => {
+        sinon.restore()
+      })
+
+      it('should update post by id', async () => {
+        const postId = 1
+        const title = 'test_title'
+
+        const mockRequest = {
+          params: { id: postId },
+          body: { title },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await updatePostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(fakePostServiceUpdatePostById, postId, { title })
+      })
+
+      it('should return a 200 code', async () => {
+        const postId = 1
+        const title = 'test_title'
+
+        const mockRequest = {
+          params: { id: postId },
+          body: { title },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await updatePostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(mockResponse.status, 200)
+      })
+    })
+
+    describe('post not found', () => {
+      before(() => {
+        let postServiceResult = null
+
+        fakePostServiceGetPostById = sinon.replace(
+          postService,
+          'updatePostById',
+          fake.resolves(postServiceResult)
+        )
+
+        updatePostByIdWithStub = updatePostById(postService)
+      })
+
+      after(() => {
+        sinon.restore()
+      })
+
+      it('should return null', async () => {
+        const postId = 1
+        const title = 'test title'
+
+        const mockRequest = {
+          params: { id: postId },
+          body: { title },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await updatePostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(mockResponse.json, { data: null })
+      })
+
+      it('should return a 404 code', async () => {
+        const postId = 1
+        const title = 'test title'
+
+        const mockRequest = {
+          params: { id: postId },
+          body: { title },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await updatePostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(mockResponse.status, 404)
+      })
+    })
+  })
+
+  describe('#deletePostById', () => {
+    describe('post found', () => {
+      before(() => {
+        fakePostServiceDeletePostById = sinon.replace(
+          postService,
+          'deletePostById',
+          fake.resolves(defaultPost())
+        )
+
+        deletePostByIdWithStub = deletePostById(postService)
+      })
+
+      after(() => {
+        sinon.restore()
+      })
+
+      it('should delete post by id', async () => {
+        const postId = 1
+
+        const mockRequest = {
+          params: { id: postId },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await deletePostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(fakePostServiceDeletePostById, postId)
+      })
+
+      it('should return a 200 code', async () => {
+        const postId = 1
+
+        const mockRequest = {
+          params: { id: postId },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await deletePostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(mockResponse.status, 200)
+      })
+    })
+
+    describe('post not found', () => {
+      before(() => {
+        fakePostServiceGetPostById = sinon.replace(
+          postService,
+          'deletePostById',
+          fake.throws(
+            new PrismaClientKnownRequestError('No record found', {
+              code: 'P2025',
+              clientVersion: 'SomeClientVersion',
+            })
+          )
+        )
+
+        deletePostByIdWithStub = deletePostById(postService)
+      })
+
+      after(() => {
+        sinon.restore()
+      })
+
+      it('should return a 404 code', async () => {
+        const postId = 1
+
+        const mockRequest = {
+          params: { id: postId },
+        } as unknown as Request
+
+        const mockResponse: any = mockedResponse()
+
+        await deletePostByIdWithStub(mockRequest, mockResponse)
+
+        sinon.assert.calledWith(mockResponse.status, 404)
+      })
+    })
+  })
+})
+
+const defaultPost = (overrides?: Partial<Post>): Post => {
+  const now = new Date()
+
+  const defaultValues: Post = {
+    id: 1,
+    title: 'Default Title',
+    description: 'Default Description',
+    userId: 1,
+    updatedAt: now,
+    createdAt: now,
+  }
+
+  return { ...defaultValues, ...overrides }
+}
+
+const mockedResponse = () => {
+  return {
+    send: stub().returnsThis(),
+    status: stub().returnsThis(),
+    json: stub().returnsThis(),
+  }
+}

--- a/api/tests/controllers/userController.spec.ts
+++ b/api/tests/controllers/userController.spec.ts
@@ -13,7 +13,6 @@ import UserService from '../../src/services/userService'
 import { getDefaultUserRepository } from '../../src/repositories/userRepository'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { ValidationCode, ValidationError } from '../../src/util/validations/ValidationError'
-import { measureMemory } from 'vm'
 
 chai.use(chaiAsPromised)
 

--- a/api/tests/repositories/postRepository.spec.ts
+++ b/api/tests/repositories/postRepository.spec.ts
@@ -1,0 +1,67 @@
+import { describe } from 'mocha'
+import chai from 'chai'
+import sinon, { replace, fake, SinonSpy } from 'sinon'
+import chaiAsPromised from 'chai-as-promised'
+import { prisma } from '../../src/prisma'
+import PostRepository from '../../src/repositories/postRepository'
+
+chai.use(chaiAsPromised)
+
+describe('PostRepository', () => {
+  let postRepository: PostRepository
+
+  let fakeFindUniqueById: SinonSpy
+  let fakeUpdateById: SinonSpy
+  let fakeDeleteById: SinonSpy
+
+  before(() => {
+    let post = {
+      id: 1,
+      title: 'any',
+      description: 'any',
+      updatedAt: new Date(),
+      createdAt: new Date(),
+    }
+
+    fakeFindUniqueById = replace(prisma.post, 'findUnique', fake.resolves(post))
+    fakeUpdateById = replace(prisma.post, 'update', fake.resolves(post))
+    fakeDeleteById = replace(prisma.post, 'delete', fake.resolves(post))
+
+    postRepository = new PostRepository(prisma.post)
+  })
+
+  describe('#getPostById', () => {
+    it('should fetch a post', async () => {
+      await postRepository.getPostById(1)
+
+      sinon.assert.calledOnce(fakeFindUniqueById)
+      sinon.assert.calledWith(fakeFindUniqueById, { where: { id: 1 } })
+    })
+  })
+
+  describe('#updatePostById', () => {
+    it('should return a post', async () => {
+      let title = 'input title'
+      let description = 'input description'
+
+      let data = {
+        title,
+        description,
+      }
+
+      await postRepository.updatePostById(1, data)
+
+      sinon.assert.calledOnce(fakeUpdateById)
+      sinon.assert.calledWith(fakeUpdateById, { where: { id: 1 }, data })
+    })
+  })
+
+  describe('#deletePostById', () => {
+    it('should return a post', async () => {
+      await postRepository.deletePostById(1)
+
+      sinon.assert.calledOnce(fakeDeleteById)
+      sinon.assert.calledWith(fakeDeleteById, { where: { id: 1 } })
+    })
+  })
+})

--- a/api/tests/repositories/postRepository.spec.ts
+++ b/api/tests/repositories/postRepository.spec.ts
@@ -10,6 +10,7 @@ chai.use(chaiAsPromised)
 describe('PostRepository', () => {
   let postRepository: PostRepository
 
+  let fakeCreatePostByUserId: SinonSpy
   let fakeFindUniqueById: SinonSpy
   let fakeUpdateById: SinonSpy
   let fakeDeleteById: SinonSpy
@@ -23,11 +24,34 @@ describe('PostRepository', () => {
       createdAt: new Date(),
     }
 
+    fakeCreatePostByUserId = replace(prisma.post, 'create', fake.resolves(post))
     fakeFindUniqueById = replace(prisma.post, 'findUnique', fake.resolves(post))
     fakeUpdateById = replace(prisma.post, 'update', fake.resolves(post))
     fakeDeleteById = replace(prisma.post, 'delete', fake.resolves(post))
 
     postRepository = new PostRepository(prisma.post)
+  })
+
+  describe('#createPostByUserId', () => {
+    it('should create a post', async () => {
+      const userId = 1
+      const title = 'input title'
+      const description = 'input description'
+
+      await postRepository.createPostByUserId(userId, {
+        title,
+        description,
+      })
+
+      sinon.assert.calledOnce(fakeCreatePostByUserId)
+      sinon.assert.calledWith(fakeCreatePostByUserId, {
+        data: {
+          userId,
+          title,
+          description,
+        },
+      })
+    })
   })
 
   describe('#getPostById', () => {
@@ -41,10 +65,10 @@ describe('PostRepository', () => {
 
   describe('#updatePostById', () => {
     it('should return a post', async () => {
-      let title = 'input title'
-      let description = 'input description'
+      const title = 'input title'
+      const description = 'input description'
 
-      let data = {
+      const data = {
         title,
         description,
       }

--- a/api/tests/services/postService.spec.ts
+++ b/api/tests/services/postService.spec.ts
@@ -139,6 +139,28 @@ describe('PostService', () => {
       sinon.restore()
     })
 
+    describe('input validation', () => {
+      it('should return a ValidationError on invalid title length', async () => {
+        const badTitle = generateString(MAX_TITLE_INPUT + 1)
+
+        const postInput = defaultPostInput({ ...{ title: badTitle } })
+
+        const response = await postService.createPostByUserId(1, postInput)
+
+        expect(response).to.be.instanceOf(ValidationError)
+      })
+
+      it('should return a ValidationError on invalid description length', async () => {
+        const badDescription = generateString(MAX_DESCRIPTION_INPUT + 1)
+
+        const postInput = defaultPostInput({ ...{ description: badDescription } })
+
+        const response = await postService.createPostByUserId(1, postInput)
+
+        expect(response).to.be.instanceOf(ValidationError)
+      })
+    })
+
     it('should return a post', async () => {
       let id = 1
       let title = 'test_title'

--- a/api/tests/services/postService.spec.ts
+++ b/api/tests/services/postService.spec.ts
@@ -4,8 +4,10 @@ import sinon, { fake } from 'sinon'
 import chaiAsPromised from 'chai-as-promised'
 import { prisma } from '../../src/prisma'
 import PostRepository from '../../src/repositories/postRepository'
-import PostService from '../../src/services/postService'
+import PostService, { MAX_DESCRIPTION_INPUT, MAX_TITLE_INPUT } from '../../src/services/postService'
 import { Post } from '@prisma/client'
+import { ValidationError } from '../../src/util/validations/ValidationError'
+import CreatePostInput from '../../src/types/CreatePostInput'
 
 chai.use(chaiAsPromised)
 
@@ -16,6 +18,94 @@ describe('PostService', () => {
   before(() => {
     postRepository = new PostRepository(prisma.post)
     postService = new PostService(postRepository)
+  })
+
+  describe('#createPostByUserId', () => {
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    describe('input validation', () => {
+      it('should return a ValidationError on null title', async () => {
+        const badTitle = null
+
+        const postInput = defaultPostInput({ ...{ title: badTitle } })
+
+        const response = await postService.createPostByUserId(1, postInput)
+
+        expect(response).to.be.instanceOf(ValidationError)
+      })
+
+      it('should return a ValidationError on undefined title', async () => {
+        const badTitle = undefined
+
+        const postInput = defaultPostInput({ ...{ title: badTitle } })
+
+        const response = await postService.createPostByUserId(1, postInput)
+
+        expect(response).to.be.instanceOf(ValidationError)
+      })
+
+      it('should return a ValidationError on null description', async () => {
+        const badDescription = null
+
+        const postInput = defaultPostInput({ ...{ description: badDescription } })
+
+        const response = await postService.createPostByUserId(1, postInput)
+
+        expect(response).to.be.instanceOf(ValidationError)
+      })
+
+      it('should return a ValidationError on undefined description', async () => {
+        const badDescription = undefined
+
+        const postInput = defaultPostInput({ ...{ description: badDescription } })
+
+        const response = await postService.createPostByUserId(1, postInput)
+
+        expect(response).to.be.instanceOf(ValidationError)
+      })
+
+      it('should return a ValidationError on invalid title length', async () => {
+        const badTitle = generateString(MAX_TITLE_INPUT + 1)
+
+        const postInput = defaultPostInput({ ...{ title: badTitle } })
+
+        const response = await postService.createPostByUserId(1, postInput)
+
+        expect(response).to.be.instanceOf(ValidationError)
+      })
+
+      it('should return a ValidationError on invalid description length', async () => {
+        const badDescription = generateString(MAX_DESCRIPTION_INPUT + 1)
+
+        const postInput = defaultPostInput({ ...{ description: badDescription } })
+
+        const response = await postService.createPostByUserId(1, postInput)
+
+        expect(response).to.be.instanceOf(ValidationError)
+      })
+    })
+
+    it('should return a post', async () => {
+      const userId = 1
+
+      const postInput = defaultPostInput()
+
+      const postCreated = {
+        id: 1,
+        userId,
+        ...postInput,
+        updatedAt: new Date(),
+        createdAt: new Date(),
+      }
+
+      sinon.replace(postRepository, 'createPostByUserId', fake.resolves(postCreated))
+
+      let post = await postService.createPostByUserId(userId, postInput)
+
+      expect(post).to.deep.equal(postCreated)
+    })
   })
 
   describe('#getPostById', () => {
@@ -104,4 +194,26 @@ const defaultPost = (overrides?: Partial<Post>): Post => {
   }
 
   return { ...defaultValues, ...overrides }
+}
+
+const defaultPostInput = (overrides?: Partial<CreatePostInput>): CreatePostInput => {
+  const defaultValues: CreatePostInput = {
+    title: 'Default title',
+    description: 'default description',
+  }
+
+  return { ...defaultValues, ...overrides }
+}
+
+const generateString = (length: number, character: string = '*'): string => {
+  if (length <= 0) {
+    return ''
+  }
+
+  let result = ''
+  while (result.length < length) {
+    result += character
+  }
+
+  return result.substring(0, length)
 }

--- a/api/tests/services/postService.spec.ts
+++ b/api/tests/services/postService.spec.ts
@@ -1,0 +1,107 @@
+import { describe } from 'mocha'
+import chai, { expect } from 'chai'
+import sinon, { fake } from 'sinon'
+import chaiAsPromised from 'chai-as-promised'
+import { prisma } from '../../src/prisma'
+import PostRepository from '../../src/repositories/postRepository'
+import PostService from '../../src/services/postService'
+import { Post } from '@prisma/client'
+
+chai.use(chaiAsPromised)
+
+describe('PostService', () => {
+  var postService: PostService
+  var postRepository: PostRepository
+
+  before(() => {
+    postRepository = new PostRepository(prisma.post)
+    postService = new PostService(postRepository)
+  })
+
+  describe('#getPostById', () => {
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should return a post if found', async () => {
+      let id = 1
+
+      const postResult = defaultPost()
+
+      sinon.replace(postRepository, 'getPostById', fake.resolves(postResult))
+
+      let post = await postService.getPostById(id)
+
+      expect(post).to.deep.equal(postResult)
+    })
+
+    it('should return null if no post is found', async () => {
+      sinon.replace(postRepository, 'getPostById', fake.resolves(null))
+
+      let post = await postService.getPostById(1)
+
+      expect(post).to.equal(null)
+    })
+  })
+
+  describe('#updatePostById', () => {
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should return a post', async () => {
+      let id = 1
+      let title = 'test_title'
+
+      let data = {
+        title,
+      }
+
+      const postResult = defaultPost({ ...data })
+
+      sinon.replace(postRepository, 'updatePostById', fake.resolves(postResult))
+
+      let post = await postService.updatePostById(id, data)
+
+      expect(post).to.deep.equal(postResult)
+    })
+  })
+
+  describe('#deletePostById', () => {
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should return a post', async () => {
+      let id = 1
+      let title = 'test_title'
+
+      let data = {
+        title,
+      }
+
+      const postResult = defaultPost({ ...data })
+
+      sinon.replace(postRepository, 'updatePostById', fake.resolves(postResult))
+
+      let post = await postService.updatePostById(id, data)
+
+      expect(post).to.deep.equal(postResult)
+    })
+  })
+})
+
+const defaultPost = (overrides?: Partial<Post>): Post => {
+  const now = new Date()
+
+  const defaultValues: Post = {
+    id: 1,
+    title: 'Default Title',
+    description: 'Default Description',
+    userId: 1,
+    updatedAt: now,
+    createdAt: now,
+  }
+
+  return { ...defaultValues, ...overrides }
+}

--- a/api/tests/services/userService.spec.ts
+++ b/api/tests/services/userService.spec.ts
@@ -46,8 +46,28 @@ describe('UserService', () => {
         expect(response).to.be.instanceOf(ValidationError)
       })
 
+      it('should return a ValidationError on undefined email', async () => {
+        const badEmail = undefined
+
+        const userInput = defaultUserInput({ ...{ email: badEmail } })
+
+        const response = await userService.createUser(userInput)
+
+        expect(response).to.be.instanceOf(ValidationError)
+      })
+
       it('should return a ValidationError on null username', async () => {
         const badUsername = null
+
+        const userInput = defaultUserInput({ ...{ username: badUsername } })
+
+        const response = await userService.createUser(userInput)
+
+        expect(response).to.be.instanceOf(ValidationError)
+      })
+
+      it('should return a ValidationError on undefined username', async () => {
+        const badUsername = undefined
 
         const userInput = defaultUserInput({ ...{ username: badUsername } })
 

--- a/api/tests/services/userService.spec.ts
+++ b/api/tests/services/userService.spec.ts
@@ -6,6 +6,8 @@ import { prisma } from '../../src/prisma'
 import UserRepository from '../../src/repositories/userRepository'
 import UserService from '../../src/services/userService'
 import { ValidationError } from '../../src/util/validations/ValidationError'
+import { User } from '@prisma/client'
+import CreateUserInput from '../../src/types/CreateUserInput'
 
 chai.use(chaiAsPromised)
 
@@ -25,85 +27,44 @@ describe('UserService', () => {
 
     describe('input validation', () => {
       it('should return a ValidationError on invalid email', async () => {
-        let badEmail = 'test'
+        const badEmail = 'test'
 
-        let id = 1
-        let username = 'test_username'
-        let fullName = 'Locker Challenge'
-        let dateOfBirth = '2023-08-12'
+        const userInput = defaultUserInput({ ...{ email: badEmail } })
 
-        let userInput = {
-          id,
-          username,
-          email: badEmail,
-          fullName,
-          dateOfBirth,
-        }
-
-        let response = await userService.createUser(userInput)
+        const response = await userService.createUser(userInput)
 
         expect(response).to.be.instanceOf(ValidationError)
       })
 
       it('should return a ValidationError on null email', async () => {
-        let badEmail = null
+        const badEmail = null
 
-        let id = 1
-        let username = 'test_username'
-        let fullName = 'Locker Challenge'
-        let dateOfBirth = '2023-08-12'
+        const userInput = defaultUserInput({ ...{ email: badEmail } })
 
-        let userInput = {
-          id,
-          username,
-          email: badEmail,
-          fullName,
-          dateOfBirth,
-        }
-
-        let response = await userService.createUser(userInput)
+        const response = await userService.createUser(userInput)
 
         expect(response).to.be.instanceOf(ValidationError)
       })
 
       it('should return a ValidationError on null username', async () => {
-        let badUsername = null
+        const badUsername = null
 
-        let id = 1
-        let fullName = 'Locker Challenge'
-        let email = 'test@test.com'
-        let dateOfBirth = '2023-08-12'
+        const userInput = defaultUserInput({ ...{ username: badUsername } })
 
-        let userInput = {
-          id,
-          username: badUsername,
-          email,
-          fullName,
-          dateOfBirth,
-        }
-
-        let response = await userService.createUser(userInput)
+        const response = await userService.createUser(userInput)
 
         expect(response).to.be.instanceOf(ValidationError)
       })
     })
 
     it('should return a user', async () => {
-      let id = 1
-      let username = 'test_username'
-      let email = 'test@test.com'
-      let fullName = 'Locker Challenge'
-      let dateOfBirth = '2023-08-12'
+      const id = 1
+      const dateOfBirth = '2023-08-12'
 
-      let userInput = {
+      const userInput = defaultUserInput({ ...{ dateOfBirth } })
+
+      const userCreated = {
         id,
-        username,
-        email,
-        fullName,
-        dateOfBirth,
-      }
-
-      let userCreated = {
         ...userInput,
         dateOfBirth: new Date(dateOfBirth),
         updatedAt: new Date(),
@@ -124,25 +85,13 @@ describe('UserService', () => {
     })
 
     it('should return a user if found', async () => {
-      let id = 1
-      let username = 'test_username'
-      let email = 'test@test.com'
-      let fullName = 'Locker Challenge'
-      let dateOfBirth = '2023-08-12'
+      const id = 1
 
-      let userFound = {
-        id,
-        username,
-        email,
-        fullName,
-        dateOfBirth: new Date(dateOfBirth),
-        updatedAt: new Date(),
-        createdAt: new Date(),
-      }
+      const userFound = defaultUser()
 
       sinon.replace(userRepository, 'getUserById', fake.resolves(userFound))
 
-      let user = await userService.getUserById(id)
+      const user = await userService.getUserById(id)
 
       expect(user).to.deep.equal(userFound)
     })
@@ -150,7 +99,7 @@ describe('UserService', () => {
     it('should return null if no user is found', async () => {
       sinon.replace(userRepository, 'getUserById', fake.resolves(null))
 
-      let user = await userService.getUserById(1)
+      const user = await userService.getUserById(1)
 
       expect(user).to.equal(null)
     })
@@ -163,28 +112,28 @@ describe('UserService', () => {
 
     describe('input validation', () => {
       it('should return a ValidationError on invalid email', async () => {
-        let badEmail = 'test'
+        const badEmail = 'test'
 
-        let data = { email: badEmail }
+        const data = { email: badEmail }
 
-        let response = await userService.updateUserById(1, data)
+        const response = await userService.updateUserById(1, data)
 
         expect(response).to.be.instanceOf(ValidationError)
       })
     })
 
     it('should return a user', async () => {
-      let id = 1
-      let username = 'test_username'
-      let email = 'test@test.com'
-      let fullName = 'Locker Challenge'
-      let dateOfBirth = '2023-08-12'
+      const id = 1
+      const username = 'test_username'
+      const email = 'test@test.com'
+      const fullName = 'Locker Challenge'
+      const dateOfBirth = '2023-08-12'
 
-      let data = {
+      const data = {
         username,
       }
 
-      let userUpdated = {
+      const userUpdated = {
         id,
         email,
         fullName,
@@ -196,7 +145,7 @@ describe('UserService', () => {
 
       sinon.replace(userRepository, 'updateUserById', fake.resolves(userUpdated))
 
-      let user = await userService.updateUserById(id, data)
+      const user = await userService.updateUserById(id, data)
 
       expect(user).to.deep.equal(userUpdated)
     })
@@ -208,17 +157,17 @@ describe('UserService', () => {
     })
 
     it('should return a user', async () => {
-      let id = 1
-      let username = 'test_username'
-      let email = 'test@test.com'
-      let fullName = 'Locker Challenge'
-      let dateOfBirth = '2023-08-12'
+      const id = 1
+      const username = 'test_username'
+      const email = 'test@test.com'
+      const fullName = 'Locker Challenge'
+      const dateOfBirth = '2023-08-12'
 
-      let data = {
+      const data = {
         username,
       }
 
-      let userUpdated = {
+      const userUpdated = {
         id,
         email,
         fullName,
@@ -230,9 +179,38 @@ describe('UserService', () => {
 
       sinon.replace(userRepository, 'updateUserById', fake.resolves(userUpdated))
 
-      let user = await userService.updateUserById(id, data)
+      const user = await userService.updateUserById(id, data)
 
       expect(user).to.deep.equal(userUpdated)
     })
   })
 })
+
+const defaultUser = (overrides?: Partial<User>): User => {
+  const now = new Date()
+
+  const defaultValues: User = {
+    id: 1,
+    fullName: 'Default fullName',
+    email: 'defaultEmail@test.com',
+    username: 'default_username',
+    dateOfBirth: now,
+    updatedAt: now,
+    createdAt: now,
+  }
+
+  return { ...defaultValues, ...overrides }
+}
+
+const defaultUserInput = (overrides?: Partial<CreateUserInput>): CreateUserInput => {
+  const now = new Date()
+
+  const defaultValues: CreateUserInput = {
+    fullName: 'Default fullName',
+    email: 'defaultEmail@test.com',
+    username: 'default_username',
+    dateOfBirth: now.toISOString(),
+  }
+
+  return { ...defaultValues, ...overrides }
+}


### PR DESCRIPTION
### Description
- Create CRUD post routes
  - `POST api/posts/user/:id`
  - `GET api/posts/:id`
  - `PUT api/posts/:id`
  - `DELETE api/posts/:id`

- Add tests

#### Callouts
Although the docs call for a create endpoint that looks like `POST api/posts`, the Prisma client requires that a `userId` be present based on the current Prisma models. This _may_ be changed, although it becomes a question of data integrity. Should posts exist without users?  I do not personally see a valid use case for this state,  so this is the approach that I decided to take (creating an endpoint that looks like `POST api/posts/user/:id`)

Alternatively, the `userId` could also be determined from login credentials such as a user session or token but that has not been implemented.

### Test plan
- Ensure DB is running locally - `docker-compose up -d`
- Start server - `npm run dev`
- Verify test plan runs without failures - `npm run test`

Since there's no UI implemented _yet_, I've been using Postman but you can also use curl
### Create post
```
curl --location --request POST 'localhost:3000/api/posts/user/:id' \
--header 'Content-Type: application/json' \
--data-raw '{
    "title": "post title",
    "description": "post description"
}'
```
### Get post by ID
(use ID from return above)
```
curl --location --request GET 'localhost:3000/api/posts/:id'
```

### Update post by ID
(use ID from return above)
```
curl --location --request PUT 'localhost:3000/api/posts/:id' \
--header 'Content-Type: application/json' \
--data-raw '{
    "title": "new title"
}'
```

### Delete post by ID
(use ID from return above)
```
curl --location --request DELETE 'localhost:3000/api/posts/:id'
```